### PR TITLE
Allow input of `tag_name`.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use clap_verbosity_flag::{Verbosity, WarnLevel};
 mod init;
 mod inspect;
 mod list;
+mod oci_ref;
 mod registry;
 mod search;
 

--- a/src/oci_ref.rs
+++ b/src/oci_ref.rs
@@ -1,0 +1,27 @@
+use std::str::FromStr;
+
+use ocipkg::ImageName;
+
+/// Opaque type for implementing additional ImageName features
+#[derive(Debug, Clone)]
+pub struct OciReference(pub ImageName);
+
+impl OciReference {
+    pub fn id(&self) -> String {
+        let id = format!("{}/{}", self.0.hostname, self.0.name);
+        id
+    }
+
+    pub fn tag_name(&self) -> String {
+        self.0.reference.to_string()
+    }
+}
+
+impl FromStr for OciReference {
+    type Err = ocipkg::error::Error;
+
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        ImageName::parse(name)
+        .map(OciReference)
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -9,6 +9,8 @@ use ocipkg::{Digest, ImageName, distribution::Client};
 use serde_json::Value as JsonValue;
 use serde::{Deserialize, Serialize};
 
+use crate::oci_ref::OciReference;
+
 // PartialOrd, Hash, Eq, Ord
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -426,11 +428,10 @@ pub fn pull_devcontainer_index<P: AsRef<Path>>(filename: P) -> ocipkg::error::Re
 }
 
 /// Pull bytes of the given OCI artifact, which is a reference to a given Feature or Template tar archive.
-pub fn pull_archive_bytes(id: &str, tag_name: &str) -> ocipkg::error::Result<Vec<u8>> {
+pub fn pull_archive_bytes(oci_ref: &OciReference) -> ocipkg::error::Result<Vec<u8>> {
     log::debug!("pull_archive_bytes");
 
-    let raw_name = format!("{id}:{tag_name}");
-    let image_name = ImageName::parse(&raw_name)?;
+    let OciReference(image_name) = oci_ref;
     let blob = get_layer_bytes(&image_name, |media_type| {
         match media_type {
             MediaType::Other(other_type) => other_type == "application/vnd.devcontainers.layer.v1+tar",


### PR DESCRIPTION
## module: oci_ref

Adds opaque wrapper of `ocipkg::ImageName`. Using `OciReference` as the _clap_ argument type means that `id` & `tag_name` can be specified as a single value.
