### PR TITLE
fix: Set archive directory size to zero.

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -597,8 +597,8 @@ impl TemplateBuilder {
         let create_directory_header = |path: &str| -> io::Result<Header> {
             let mut header = Header::new_gnu();
             header.set_entry_type(EntryType::Directory);
-            header.set_size(0);
             header.set_path(path)?;
+            header.set_size(0);
             header.set_mtime(mtime);
             header.set_mode(0o775);
             header.set_uid(1000);

--- a/src/init.rs
+++ b/src/init.rs
@@ -597,6 +597,7 @@ impl TemplateBuilder {
         let create_directory_header = |path: &str| -> io::Result<Header> {
             let mut header = Header::new_gnu();
             header.set_entry_type(EntryType::Directory);
+            header.set_size(0);
             header.set_path(path)?;
             header.set_mtime(mtime);
             header.set_mode(0o775);


### PR DESCRIPTION
Fixes problem with extracting the custom "empty template".